### PR TITLE
feat: Update dependency versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.1.2 - 2018-03-07
+
+- Relax ruby version to >= 2.2 for now
+- Relax rubocop dependency version
+
 ## v0.1.1 - 2018-03-06
 
 - Add `Bundler/OrderedGems` cop for including comments as sections

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    autocop (0.1.1)
-      rubocop (= 0.52.1)
-      rubocop-rspec (= 1.22.1)
+    autocop (0.1.2)
+      rubocop (>= 0.52.1)
+      rubocop-rspec (>= 1.22.1)
 
 GEM
   remote: https://rubygems.org/
@@ -34,15 +34,15 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
-    rubocop (0.52.1)
+    rubocop (0.53.0)
       parallel (~> 1.10)
-      parser (>= 2.4.0.2, < 3.0)
+      parser (>= 2.5)
       powerpack (~> 0.1)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
-    rubocop-rspec (1.22.1)
-      rubocop (>= 0.52.1)
+    rubocop-rspec (1.24.0)
+      rubocop (>= 0.53.0)
     ruby-progressbar (1.9.0)
     unicode-display_width (1.3.0)
 

--- a/autocop.gemspec
+++ b/autocop.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = %w[lib]
 
-  spec.required_ruby_version = ['>= 2.4.0', '< 2.6.0']
+  spec.required_ruby_version = ['>= 2.2.0', '< 2.6.0']
 
-  spec.add_dependency 'rubocop',       '0.52.1'
-  spec.add_dependency 'rubocop-rspec', '1.22.1'
+  spec.add_dependency 'rubocop',       '>= 0.52.1'
+  spec.add_dependency 'rubocop-rspec', '>= 1.22.1'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'pry'

--- a/autocop.gemspec
+++ b/autocop.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'autocop/version'
 

--- a/lib/autocop/version.rb
+++ b/lib/autocop/version.rb
@@ -1,3 +1,3 @@
 module Autocop
-  VERSION = '0.1.1'.freeze
+  VERSION = '0.1.2'.freeze
 end


### PR DESCRIPTION
- Allow ruby >= 2.2
- Allow rubocop >= 0.52