### PR TITLE
fix: Badge for gem version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Autocop
 
-[![Latest Version](https://img.shields.io/gem/v/autocop.svg)](http://rubygems.org/gems/autocop)
+[![Gem Version](https://badge.fury.io/rb/autocop.svg)](https://badge.fury.io/rb/autocop)
 [![Build Status](https://travis-ci.org/autolist/autocop.svg?branch=master)](https://travis-ci.org/autolist/autocop)
 
 Autolist approved ruby style rules to write code without worrying about upsetting


### PR DESCRIPTION
## What

Badge link for gem version was broken.

## Changes

- Use correct badge link