### PR TITLE
feat/prefer is_expected to should

### DIFF
--- a/.autocop-rubocop.yml
+++ b/.autocop-rubocop.yml
@@ -521,7 +521,8 @@ RSpec/DescribeClass:
     - 'spec/features/**/*'
 
 RSpec/ImplicitExpect:
-  EnforcedStyle: should
+  Enabled: true
+  EnforcedStyle: is_expected
 
 RSpec/LeadingSubject:
   Enabled: false


### PR DESCRIPTION
This is because `should` has been deprecated.