### PR TITLE
correct the naming of the UnneededCopDisableDirective

### DIFF
--- a/.autocop-rubocop.yml
+++ b/.autocop-rubocop.yml
@@ -182,7 +182,7 @@ Lint/UnderscorePrefixedVariableName:
   Enabled: true
 
 # Supports --auto-correct
-Lint/UnneededDisable:
+Lint/UnneededCopDisableDirective:
   Description: 'Checks for rubocop:disable comments that can be removed. Note: this
     cop is not disabled when disabling all cops. It must be explicitly disabled.'
   Enabled: true


### PR DESCRIPTION
Looks like it changed in rubocop [0.53.0](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md#0530-2018-03-05)