### PR TITLE
use only_raise for Style/SignalException

### DIFF
--- a/.autocop-rubocop.yml
+++ b/.autocop-rubocop.yml
@@ -1526,7 +1526,7 @@ Style/SignalException:
   Description: Checks for proper usage of fail and raise.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#fail-method
   Enabled: true
-  EnforcedStyle: semantic
+  EnforcedStyle: only_raise
   SupportedStyles:
     - only_raise
     - only_fail


### PR DESCRIPTION
After bouncing around the team for a while, seems like consensus is that we should be only using `raise` for raising exceptions. `fail` is against the bbatsov style guide, and isn't currently widely used at autolist.