### PR TITLE
Update: rename namespace for FlipFlop

### DIFF
--- a/.autocop-rubocop.yml
+++ b/.autocop-rubocop.yml
@@ -994,7 +994,7 @@ Layout/FirstParameterIndentation:
     - special_for_inner_method_call_in_parentheses
   IndentationWidth:
 
-Style/FlipFlop:
+Lint/FlipFlop:
   Description: Checks for flip flops
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-flip-flops
   Enabled: true


### PR DESCRIPTION
See: https://www.pivotaltracker.com/story/show/164389124

It's moved places in rubocop: https://rubocop.readthedocs.io/en/latest/cops_lint/#lintflipflop

[#164389124]