### PR TITLE
Config: remove duplicated configuration

### DIFF
--- a/.autocop-rubocop.yml
+++ b/.autocop-rubocop.yml
@@ -1902,15 +1902,3 @@ Style/WordArray:
   MinSize: 0
   WordRegex: !ruby/regexp /\A[\p{Word}\n\t]+\z/
 
-Metrics/MethodLength:
-  Max: 30
-
-Metrics/LineLength:
-  Max: 200
-
-Style/NumericLiterals:
-  MinDigits: 7
-
-Metrics/ModuleLength:
-  CountComments: false
-  Max: 300


### PR DESCRIPTION
See: https://www.pivotaltracker.com/story/show/164407307

We had some configuration that was a duplication of earlier content in this file, which caused Overcommit to barf on the warnings it generated.