### PR TITLE
fix: fix no department warning for documentation

### DIFF
--- a/.autocop-rubocop.yml
+++ b/.autocop-rubocop.yml
@@ -25,7 +25,7 @@ AllCops:
 Rails:
   Enabled: true
 
-Documentation:
+Style/Documentation:
   Enabled: false
 
 Bundler/OrderedGems:


### PR DESCRIPTION
changed Documentation to Style/Documentation in .autocop-rubocop.yml

we keep getting this warning when running rubocop using autocop, and it's polluting overcommit output:

```
Analyze with RuboCop........................................[RuboCop] FAILED
Unexpected output: unable to determine line number or type of error/warning for output:
/Users/tomlubitz/.rvm/gems/ruby-2.5.1@transmogrifier/gems/autocop-0.3.2/.autocop-rubocop.yml: Warning: no department given for Documentation.

✗ One or more pre-commit hooks failed
```