### PR TITLE
fix: rename unneeded->redundant for 0.76 support

### DIFF
--- a/.autocop-rubocop.yml
+++ b/.autocop-rubocop.yml
@@ -25,9 +25,6 @@ AllCops:
 Rails:
   Enabled: true
 
-Style/Documentation:
-  Enabled: false
-
 Bundler/OrderedGems:
   TreatCommentsAsGroupSeparators: true
   Enabled: true
@@ -185,7 +182,7 @@ Lint/UnderscorePrefixedVariableName:
   Enabled: true
 
 # Supports --auto-correct
-Lint/UnneededCopDisableDirective:
+Lint/RedundantCopDisableDirective:
   Description: 'Checks for rubocop:disable comments that can be removed. Note: this
     cop is not disabled when disabling all cops. It must be explicitly disabled.'
   Enabled: true
@@ -1812,17 +1809,17 @@ Style/UnlessElse:
   Enabled: true
 
 # Supports --auto-correct
-Style/UnneededCapitalW:
+Style/RedundantCapitalW:
   Description: Checks for %W when interpolation is not needed.
   Enabled: true
 
 # Supports --auto-correct
-Style/UnneededInterpolation:
+Style/RedundantInterpolation:
   Description: Checks for strings that are just an interpolated expression.
   Enabled: true
 
 # Supports --auto-correct
-Style/UnneededPercentQ:
+Style/RedundantPercentQ:
   Description: Checks for %q/%Q when single quotes or double quotes would do.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#percent-q
   Enabled: true

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 /spec/reports/
 /tmp/
 
+.idea
+
 # rspec failure tracking
 .rspec_status
 

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,8 @@ require 'rubygems'
 require 'bundler'
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
-require 'rubocop/rake_task'
+require 'rubocop'
+require 'rubocop/cli'
 
 Bundler::GemHelper.install_tasks
 
@@ -14,7 +15,8 @@ task default: :test
 # Rubocop
 desc 'Run Rubocop lint checks'
 task :rubocop do
-  RuboCop::RakeTask.new
+  result = RuboCop::CLI.new.run(%w[-c .autocop-rubocop.yml])
+  exit result unless result.zero?
 end
 
 desc 'Run specs'


### PR DESCRIPTION
Update cop configs to support rubocop 0.76.0

* Update `Rakefile` to run rubocop using the `.autocop-rubocop.yml` file instead of the default config. (tested this to make sure it was reporting error conditions correctly)
* Remove duplicate `Style/Documentation` autocop config
* Rename `Unneeded*` to `Redundant*` in autocop config as per error messages. (breaking changes introduced in rubocop 0.76.0 🙄)
* gitignore jetbrains folder (`.idea`)