### PR TITLE
remove Style/BracesAroundHashParameters cop which is no longer supported

### DIFF
--- a/.autocop-rubocop.yml
+++ b/.autocop-rubocop.yml
@@ -635,16 +635,6 @@ Layout/BlockEndNewline:
   Description: Put end statement of multiline block on its own line.
   Enabled: true
 
-# Supports --auto-correct
-Style/BracesAroundHashParameters:
-  Description: Enforce braces style around hash parameters.
-  Enabled: true
-  EnforcedStyle: no_braces
-  SupportedStyles:
-    - braces
-    - no_braces
-    - context_dependent
-
 Style/CaseEquality:
   Description: Avoid explicit use of the case equality operator(===).
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-case-equality


### PR DESCRIPTION
this cop was removed in rubocop 0.80.0 with no replacement

see: https://github.com/rubocop-hq/rubocop/issues/7641

Signed-off-by: Pablo Kang <pablo@autolist.com>